### PR TITLE
Fixed URLSearchParams constructor call

### DIFF
--- a/src/sample-account-setup.ts
+++ b/src/sample-account-setup.ts
@@ -98,11 +98,12 @@ async function ensureSchedule(medplum: MedplumClient, practitioner: Practitioner
 async function ensureSlots(medplum: MedplumClient, schedule: Schedule, slotDate: Date): Promise<void> {
   const existingSlots = await medplum.searchResources(
     'Slot',
-    new URLSearchParams({
-      _summary: 'true',
-      schedule: getReferenceString(schedule),
-      start: ['gt' + slotDate.toISOString(), 'lt' + new Date(slotDate.getTime() + 24 * 60 * 60 * 1000).toISOString()],
-    })
+    new URLSearchParams([
+      ['_summary', 'true'],
+      ['schedule', getReferenceString(schedule)],
+      ['start', 'gt' + slotDate.toISOString()],
+      ['start', 'lt' + new Date(slotDate.getTime() + 24 * 60 * 60 * 1000).toISOString()],
+    ])
   );
 
   if (existingSlots.length > 0) {


### PR DESCRIPTION
TypeScript definition for `URLSearchParams` constructor:

```ts
var URLSearchParams: new (init?: string | URLSearchParams | Record<string, string | readonly string[]> | Iterable<[string, string]> | readonly [string, string][] | undefined) => URLSearchParams
```

Before, we used the `Record<string, string[]>` variant, but apparently that is not widely available.

Now, we use the `readonly [string, string][]` variant, which appears to be ubiquitous.

https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/URLSearchParams