### PR TITLE
fix(build) Update deprecated import assertion into import attribute

### DIFF
--- a/esbuild-script.mjs
+++ b/esbuild-script.mjs
@@ -5,7 +5,7 @@
 
 import esbuild from 'esbuild';
 import { glob } from 'glob';
-import botLayer from '@medplum/bot-layer/package.json' assert { type: 'json' };
+import botLayer from '@medplum/bot-layer/package.json' with { type: 'json' };
 
 // Find all TypeScript files in your source directory
 const entryPoints = glob.sync('./src/**/*.ts').filter((file) => !file.endsWith('test.ts'));

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "root": true
   },
   "devDependencies": {
+    "@medplum/bot-layer": "^3.1.8",
     "@medplum/cli": "3.1.8",
     "@medplum/core": "3.1.8",
     "@medplum/eslint-config": "3.1.8",
@@ -42,6 +43,7 @@
     "esbuild": "0.21.4",
     "form-data": "4.0.0",
     "glob": "^10.4.1",
+    "jose": "^5.4.0",
     "node-fetch": "2.7.0",
     "pdfmake": "0.2.10",
     "rimraf": "5.0.7",


### PR DESCRIPTION
Both `@medplum/bot-layer` https://github.com/medplum/medplum-demo-bots/blob/d120822fe8469ec5245cb5aaa4c70f1b298e3f47/esbuild-script.mjs#L8

and `jose` module  https://github.com/medplum/medplum-demo-bots/blob/d120822fe8469ec5245cb5aaa4c70f1b298e3f47/src/epic/epic-query-patient.ts#L4

Need to be imported in `package.json`.
 
Also based on https://v8.dev/features/import-attributes#deprecation-and-eventual-removal-of-assert and my `npm run build` failing, the assert keyword in the bot-layer json import statement causes a build error. 

fixes #198 and more